### PR TITLE
Add dynamic literary device pages

### DIFF
--- a/public/definition.html
+++ b/public/definition.html
@@ -36,6 +36,20 @@
     .back-button:hover {
       transform: scale(1.05);
     }
+    .next-button {
+      background: linear-gradient(135deg, #6bdbbd 80%, #e4fff8 100%);
+      color: #fff;
+      border: none;
+      padding: 12px 24px;
+      border-radius: 8px;
+      cursor: pointer;
+      font-size: 1em;
+      margin-bottom: 20px;
+      transition: transform 0.2s;
+    }
+    .next-button:hover {
+      transform: scale(1.05);
+    }
     .content {
       background: rgba(255,255,255,0.06);
       border-radius: 12px;
@@ -58,7 +72,10 @@
 </head>
 <body>
   <div class="container">
-    <button class="back-button" onclick="history.back()">← Back to Literary Deviousness</button>
+    <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:20px;gap:10px;flex-wrap:wrap;">
+      <button class="back-button" onclick="history.back()">← Back to Literary Deviousness</button>
+      <button class="next-button" id="nextBtn">Next →</button>
+    </div>
     <h1 id="title">Loading...</h1>
     <div id="content" class="content loading">Loading definition...</div>
   </div>
@@ -99,6 +116,24 @@
         console.error('Error loading definition:', error);
       }
     }
+
+    // Setup next button based on definitions list
+    fetch('/definitions-list')
+      .then(res => res.json())
+      .then(files => {
+        const index = files.indexOf(filename);
+        if (index !== -1 && index + 1 < files.length) {
+          const nextFile = files[index + 1];
+          document.getElementById('nextBtn').onclick = () => {
+            window.location.href = 'definition.html?file=' + encodeURIComponent(nextFile);
+          };
+        } else {
+          document.getElementById('nextBtn').style.display = 'none';
+        }
+      })
+      .catch(() => {
+        document.getElementById('nextBtn').style.display = 'none';
+      });
   </script>
 </body>
 </html>

--- a/public/elements.html
+++ b/public/elements.html
@@ -17,9 +17,14 @@
       padding: 20px;
     }
     h1 {
-      margin-bottom: 24px;
+      margin-bottom: 8px;
       font-size: 1.8em;
       font-weight: 700;
+    }
+    p.intro {
+      margin-top: 0;
+      margin-bottom: 24px;
+      font-size: 1.1em;
     }
     .element-grid {
       background: rgba(255,255,255,0.06);
@@ -64,14 +69,6 @@
       font-weight: 600;
       margin-bottom: 4px;
     }
-    .section-header {
-      grid-column: 1 / -1;
-      text-align: center;
-      font-size: 1.3em;
-      font-weight: 700;
-      margin: 20px 0 10px 0;
-      color: #facc15;
-    }
     #drafting-area {
       position: fixed;
       left: 24px;
@@ -94,405 +91,40 @@
 </head>
 <body>
   <h1>Literary Deviousness</h1>
+  <p class="intro">Literary Devices are what writing is made up of. These are the foundation.</p>
   <button id="drafting-area" onclick="goTo('drafting')">Drafting Area</button>
-  <div class="element-grid">
-    
-    <!-- Core Elements -->
-    <button class="element" onclick="goToDefinition('desire def.txt')">
-      <span class="element-number">1</span>
-      <div class="element-title">Desire</div>
-    </button>
-    <button class="element" onclick="goToDefinition('stakes def.txt')">
-      <span class="element-number">2</span>
-      <div class="element-title">Stakes</div>
-    </button>
-    <button class="element" onclick="goToDefinition('CONFLICT.txt')">
-      <span class="element-number">3</span>
-      <div class="element-title">Conflict</div>
-    </button>
-    <button class="element" onclick="goToDefinition('decision def.txt')">
-      <span class="element-number">4</span>
-      <div class="element-title">Decision</div>
-    </button>
-    <button class="element" onclick="goToDefinition('change definition.txt')">
-      <span class="element-number">5</span>
-      <div class="element-title">Change</div>
-    </button>
-    <button class="element" onclick="goToDefinition('outcome')">
-      <span class="element-number">6</span>
-      <div class="element-title">Outcome</div>
-    </button>
+  <div class="element-grid" id="elements"></div>
 
-    <!-- Characters Section -->
-    <div class="section-header">Characters</div>
-    <button class="element" onclick="goToDefinition('character backstory')">
-      <span class="element-number">7</span>
-      <div class="element-title">Character Backstory</div>
-    </button>
-    <button class="element" onclick="goToDefinition('character body logic')">
-      <span class="element-number">8</span>
-      <div class="element-title">Character Body Logic</div>
-    </button>
-    <button class="element" onclick="goToDefinition('character decision style')">
-      <span class="element-number">9</span>
-      <div class="element-title">Character Decision Style</div>
-    </button>
-    <button class="element" onclick="goToDefinition('character description')">
-      <span class="element-number">10</span>
-      <div class="element-title">Character Description</div>
-    </button>
-    <button class="element" onclick="goToDefinition('character drive')">
-      <span class="element-number">11</span>
-      <div class="element-title">Character Drive</div>
-    </button>
-    <button class="element" onclick="goToDefinition('character flaw')">
-      <span class="element-number">12</span>
-      <div class="element-title">Character Flaw</div>
-    </button>
-    <button class="element" onclick="goToDefinition('character identity')">
-      <span class="element-number">13</span>
-      <div class="element-title">Character Identity</div>
-    </button>
-    <button class="element" onclick="goToDefinition('character motivation')">
-      <span class="element-number">14</span>
-      <div class="element-title">Character Motivation</div>
-    </button>
-    <button class="element" onclick="goToDefinition('character wound')">
-      <span class="element-number">15</span>
-      <div class="element-title">Character Wound</div>
-    </button>
-    <button class="element" onclick="goToDefinition('character truth')">
-      <span class="element-number">16</span>
-      <div class="element-title">Character Truth</div>
-    </button>
-    <button class="element" onclick="goToDefinition('archetypal characters')">
-      <span class="element-number">17</span>
-      <div class="element-title">Archetypal Characters</div>
-    </button>
-    <button class="element" onclick="goToDefinition('dynamic character')">
-      <span class="element-number">18</span>
-      <div class="element-title">Dynamic Character</div>
-    </button>
-    <button class="element" onclick="goToDefinition('flat character')">
-      <span class="element-number">19</span>
-      <div class="element-title">Flat Character</div>
-    </button>
-    <button class="element" onclick="goToDefinition('round characters')">
-      <span class="element-number">20</span>
-      <div class="element-title">Round Characters</div>
-    </button>
-    <button class="element" onclick="goToDefinition('static character')">
-      <span class="element-number">21</span>
-      <div class="element-title">Static Character</div>
-    </button>
-    <button class="element" onclick="goToDefinition('symbolic character')">
-      <span class="element-number">22</span>
-      <div class="element-title">Symbolic Character</div>
-    </button>
-    <button class="element" onclick="goToDefinition('the foil')">
-      <span class="element-number">23</span>
-      <div class="element-title">The Foil</div>
-    </button>
-    <button class="element" onclick="goToDefinition('the hero')">
-      <span class="element-number">24</span>
-      <div class="element-title">The Hero</div>
-    </button>
-    <button class="element" onclick="goToDefinition('the mentor')">
-      <span class="element-number">25</span>
-      <div class="element-title">The Mentor</div>
-    </button>
-    <button class="element" onclick="goToDefinition('the villain')">
-      <span class="element-number">26</span>
-      <div class="element-title">The Villain</div>
-    </button>
-    <button class="element" onclick="goToDefinition('sidekick')">
-      <span class="element-number">27</span>
-      <div class="element-title">Sidekick</div>
-    </button>
-    <button class="element" onclick="goToDefinition('character roles')">
-      <span class="element-number">28</span>
-      <div class="element-title">Character Roles</div>
-    </button>
-    <button class="element" onclick="goToDefinition('role dynamics 2')">
-      <span class="element-number">29</span>
-      <div class="element-title">Role Dynamics 2</div>
-    </button>
-    <button class="element" onclick="goToDefinition('character role dynamics 3')">
-      <span class="element-number">30</span>
-      <div class="element-title">Character Role Dynamics 3</div>
-    </button>
-    <button class="element" onclick="goToDefinition('character role interaction')">
-      <span class="element-number">31</span>
-      <div class="element-title">Character Role Interaction</div>
-    </button>
-    <button class="element" onclick="goToDefinition('negative arc')">
-      <span class="element-number">32</span>
-      <div class="element-title">Negative Arc</div>
-    </button>
-    <button class="element" onclick="goToDefinition('positive arc')">
-      <span class="element-number">33</span>
-      <div class="element-title">Positive Arc</div>
-    </button>
-    <button class="element" onclick="goToDefinition('flat arc')">
-      <span class="element-number">34</span>
-      <div class="element-title">Flat Arc</div>
-    </button>
-    <button class="element" onclick="goToDefinition('mixed arcs')">
-      <span class="element-number">35</span>
-      <div class="element-title">Mixed Arcs</div>
-    </button>
-    <button class="element" onclick="goToDefinition('final character arcs 1')">
-      <span class="element-number">36</span>
-      <div class="element-title">Final Character Arcs 1</div>
-    </button>
-    <button class="element" onclick="goToDefinition('final character arc 2')">
-      <span class="element-number">37</span>
-      <div class="element-title">Final Character Arc 2</div>
-    </button>
-    <button class="element" onclick="goToDefinition('final character arc 3')">
-      <span class="element-number">38</span>
-      <div class="element-title">Final Character Arc 3</div>
-    </button>
-
-    <!-- Structure & Plot Section -->
-    <div class="section-header">Structure & Plot</div>
-    <button class="element" onclick="goToDefinition('beats')">
-      <span class="element-number">39</span>
-      <div class="element-title">Beats</div>
-    </button>
-    <button class="element" onclick="goToDefinition('beats build scenes')">
-      <span class="element-number">40</span>
-      <div class="element-title">Beats Build Scenes</div>
-    </button>
-    <button class="element" onclick="goToDefinition('scene 1')">
-      <span class="element-number">41</span>
-      <div class="element-title">Scene 1</div>
-    </button>
-    <button class="element" onclick="goToDefinition('scenes 2')">
-      <span class="element-number">42</span>
-      <div class="element-title">Scenes 2</div>
-    </button>
-    <button class="element" onclick="goToDefinition('scene starters')">
-      <span class="element-number">43</span>
-      <div class="element-title">Scene Starters</div>
-    </button>
-    <button class="element" onclick="goToDefinition('scene enders')">
-      <span class="element-number">44</span>
-      <div class="element-title">Scene Enders</div>
-    </button>
-    <button class="element" onclick="goToDefinition('advanced scene starters and enders')">
-      <span class="element-number">45</span>
-      <div class="element-title">Advanced Scene Starters and Enders</div>
-    </button>
-    <button class="element" onclick="goToDefinition('scene transitions')">
-      <span class="element-number">46</span>
-      <div class="element-title">Scene Transitions</div>
-    </button>
-    <button class="element" onclick="goToDefinition('scenes build acts')">
-      <span class="element-number">47</span>
-      <div class="element-title">Scenes Build Acts</div>
-    </button>
-    <button class="element" onclick="goToDefinition('acts build arcs')">
-      <span class="element-number">48</span>
-      <div class="element-title">Acts Build Arcs</div>
-    </button>
-    <button class="element" onclick="goToDefinition('ARCS UNIFY INTO THE NOVEL')">
-      <span class="element-number">49</span>
-      <div class="element-title">Arcs Unify Into The Novel</div>
-    </button>
-    <button class="element" onclick="goToDefinition('pacing part one')">
-      <span class="element-number">50</span>
-      <div class="element-title">Pacing Part One</div>
-    </button>
-    <button class="element" onclick="goToDefinition('pacing part two')">
-      <span class="element-number">51</span>
-      <div class="element-title">Pacing Part Two</div>
-    </button>
-    <button class="element" onclick="goToDefinition('pacing part three')">
-      <span class="element-number">52</span>
-      <div class="element-title">Pacing Part Three</div>
-    </button>
-    <button class="element" onclick="goToDefinition('setting')">
-      <span class="element-number">53</span>
-      <div class="element-title">Setting</div>
-    </button>
-    <button class="element" onclick="goToDefinition('dialouge part one')">
-      <span class="element-number">54</span>
-      <div class="element-title">Dialogue Part One</div>
-    </button>
-    <button class="element" onclick="goToDefinition('dialouge part two')">
-      <span class="element-number">55</span>
-      <div class="element-title">Dialogue Part Two</div>
-    </button>
-    <button class="element" onclick="goToDefinition('Exposition')">
-      <span class="element-number">56</span>
-      <div class="element-title">Exposition</div>
-    </button>
-    <button class="element" onclick="goToDefinition('sensory detail.txt')">
-      <span class="element-number">57</span>
-      <div class="element-title">Sensory Detail</div>
-    </button>
-    <button class="element" onclick="goToDefinition('point of view')">
-      <span class="element-number">58</span>
-      <div class="element-title">Point of View</div>
-    </button>
-    <button class="element" onclick="goToDefinition('subtext')">
-      <span class="element-number">59</span>
-      <div class="element-title">Subtext</div>
-    </button>
-    <button class="element" onclick="goToDefinition('planting and payoff')">
-      <span class="element-number">60</span>
-      <div class="element-title">Planting and Payoff</div>
-    </button>
-    <button class="element" onclick="goToDefinition('reader manipulators part one')">
-      <span class="element-number">61</span>
-      <div class="element-title">Reader Manipulators Part One</div>
-    </button>
-    <button class="element" onclick="goToDefinition('reader manipulators part 2')">
-      <span class="element-number">62</span>
-      <div class="element-title">Reader Manipulators Part 2</div>
-    </button>
-    <button class="element" onclick="goToDefinition('reader manipulators part 3')">
-      <span class="element-number">63</span>
-      <div class="element-title">Reader Manipulators Part 3</div>
-    </button>
-    <button class="element" onclick="goToDefinition('reader manipulators part 3ish')">
-      <span class="element-number">64</span>
-      <div class="element-title">Reader Manipulators Part 3ish</div>
-    </button>
-    <button class="element" onclick="goToDefinition('narrative devices part 1')">
-      <span class="element-number">65</span>
-      <div class="element-title">Narrative Devices Part 1</div>
-    </button>
-    <button class="element" onclick="goToDefinition('narrative devices part 2')">
-      <span class="element-number">66</span>
-      <div class="element-title">Narrative Devices Part 2</div>
-    </button>
-    <button class="element" onclick="goToDefinition('metaphore')">
-      <span class="element-number">67</span>
-      <div class="element-title">Metaphore</div>
-    </button>
-    <button class="element" onclick="goToDefinition('types of metaphors')">
-      <span class="element-number">68</span>
-      <div class="element-title">Types of Metaphors</div>
-    </button>
-    <button class="element" onclick="goToDefinition('symbolism')">
-      <span class="element-number">69</span>
-      <div class="element-title">Symbolism</div>
-    </button>
-    <button class="element" onclick="goToDefinition('mood')">
-      <span class="element-number">70</span>
-      <div class="element-title">Mood</div>
-    </button>
-    <button class="element" onclick="goToDefinition('motif')">
-      <span class="element-number">71</span>
-      <div class="element-title">Motif</div>
-    </button>
-    <button class="element" onclick="goToDefinition('tone')">
-      <span class="element-number">72</span>
-      <div class="element-title">Tone</div>
-    </button>
-    <button class="element" onclick="goToDefinition('repetition')">
-      <span class="element-number">73</span>
-      <div class="element-title">Repetition</div>
-    </button>
-    <button class="element" onclick="goToDefinition('suspense')">
-      <span class="element-number">74</span>
-      <div class="element-title">Suspense</div>
-    </button>
-    <button class="element" onclick="goToDefinition('suspense part two')">
-      <span class="element-number">75</span>
-      <div class="element-title">Suspense Part Two</div>
-    </button>
-
-    <!-- Language & Style Section -->
-    <div class="section-header">Language & Style</div>
-    <button class="element" onclick="goToDefinition('grammer part one')">
-      <span class="element-number">76</span>
-      <div class="element-title">Grammar Part One</div>
-    </button>
-    <button class="element" onclick="goToDefinition('grammer part two')">
-      <span class="element-number">77</span>
-      <div class="element-title">Grammar Part Two</div>
-    </button>
-    <button class="element" onclick="goToDefinition('grammer part three')">
-      <span class="element-number">78</span>
-      <div class="element-title">Grammar Part Three</div>
-    </button>
-    <button class="element" onclick="goToDefinition('punctuation')">
-      <span class="element-number">79</span>
-      <div class="element-title">Punctuation</div>
-    </button>
-    <button class="element" onclick="goToDefinition('theme part one')">
-      <span class="element-number">80</span>
-      <div class="element-title">Theme Part One</div>
-    </button>
-    <button class="element" onclick="goToDefinition('theme part two')">
-      <span class="element-number">81</span>
-      <div class="element-title">Theme Part Two</div>
-    </button>
-    <button class="element" onclick="goToDefinition('theme part three')">
-      <span class="element-number">82</span>
-      <div class="element-title">Theme Part Three</div>
-    </button>
-
-    <!-- Theme & Meaning Section -->
-    <div class="section-header">Theme & Meaning</div>
-    <button class="element" onclick="goToDefinition('theme applied part one')">
-      <span class="element-number">83</span>
-      <div class="element-title">Theme Applied Part One</div>
-    </button>
-    <button class="element" onclick="goToDefinition('theme applied part two')">
-      <span class="element-number">84</span>
-      <div class="element-title">Theme Applied Part Two</div>
-    </button>
-    <button class="element" onclick="goToDefinition('the writers voice')">
-      <span class="element-number">85</span>
-      <div class="element-title">The Writers Voice</div>
-    </button>
-    <button class="element" onclick="goToDefinition('being an emotional writer')">
-      <span class="element-number">86</span>
-      <div class="element-title">Being an Emotional Writer</div>
-    </button>
-    <button class="element" onclick="goToDefinition('short stories part one')">
-      <span class="element-number">87</span>
-      <div class="element-title">Short Stories Part One</div>
-    </button>
-    <button class="element" onclick="goToDefinition('short stories part two')">
-      <span class="element-number">88</span>
-      <div class="element-title">Short Stories Part Two</div>
-    </button>
-    <button class="element" onclick="goToDefinition('short stories part three')">
-      <span class="element-number">89</span>
-      <div class="element-title">Short Stories Part Three</div>
-    </button>
-    <button class="element" onclick="goToDefinition('3 act structure part 1')">
-      <span class="element-number">90</span>
-      <div class="element-title">3 Act Structure Part 1</div>
-    </button>
-    <button class="element" onclick="goToDefinition('act 2')">
-      <span class="element-number">91</span>
-      <div class="element-title">Act 2</div>
-    </button>
-    <button class="element" onclick="goToDefinition('act 3')">
-      <span class="element-number">92</span>
-      <div class="element-title">Act 3</div>
-    </button>
-
-  </div>
   <script>
-    function goTo(element) {
-      // Navigate to the corresponding HTML page
-      window.location.href = element + '.html';
+    function goTo(page) {
+      window.location.href = page + '.html';
     }
-    
+
     function goToDefinition(filename) {
-      // Navigate to a page that displays the definition file content
       window.location.href = 'definition.html?file=' + encodeURIComponent(filename);
     }
+
+    function formatTitle(filename) {
+      let title = filename.replace(/\.(txt|md|jsx)$/i, '');
+      return title.charAt(0).toUpperCase() + title.slice(1);
+    }
+
+    fetch('/definitions-list')
+      .then(res => res.json())
+      .then(files => {
+        const grid = document.getElementById('elements');
+        files.forEach((file, idx) => {
+          const btn = document.createElement('button');
+          btn.className = 'element';
+          btn.innerHTML = `<span class="element-number">${idx + 1}</span><div class="element-title">${formatTitle(file)}</div>`;
+          btn.onclick = () => goToDefinition(file);
+          grid.appendChild(btn);
+        });
+      })
+      .catch(err => {
+        console.error('Error loading definitions list:', err);
+      });
   </script>
-  
-  <!-- Ray Ray Integration -->
   <script src="/js/rayray.js"></script>
   <script src="/js/rayray-ui.js"></script>
 </body>

--- a/server.js
+++ b/server.js
@@ -60,6 +60,18 @@ app.get('/definitions/:filename', (req, res) => {
   });
 });
 
+// Provide list of available definition files
+app.get('/definitions-list', (req, res) => {
+  const dirPath = path.join(__dirname, 'definitions');
+  fs.readdir(dirPath, (err, files) => {
+    if (err) {
+      console.error('Error reading definitions directory:', err);
+      return res.status(500).json({ error: 'Could not load definitions' });
+    }
+    res.json(files);
+  });
+});
+
 // Serve writer type profiles
 app.get('/profile/:type', (req, res) => {
   const slug = req.params.type.toLowerCase();


### PR DESCRIPTION
## Summary
- generate device tiles dynamically from `/definitions` on `Literary Deviousness` page
- show introductory text
- expose `/definitions-list` endpoint
- add next button on definition page

## Testing
- `npm test` *(fails: Missing script)*
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_6879026ff634832f81672cb27107d4ea