### PR TITLE
Enhance scene selection analysis

### DIFF
--- a/drafting room/Scene Selection Handler
+++ b/drafting room/Scene Selection Handler
@@ -3,13 +3,24 @@ function getSceneById(id) {
   return scenes.find(scene => scene.id === id);
 }
 
+// Holds the latest analysis so other modules can reuse it
+let currentAnalysisResult = null;
+
 function selectSceneForRayRay(sceneId, listItem) {
   // Highlight the selected scene
   document.querySelectorAll('#scene-list li').forEach(li => li.classList.remove('active'));
   if (listItem) listItem.classList.add('active');
 
   const scene = getSceneById(sceneId);
-  if (!scene) return;
+  if (!scene || !scene.title) return;
+
+  const fullScene = getSceneByTitle(scene.title);
+  if (!fullScene) return;
+
+  const text = fullScene.content || fullScene.text || '';
+  currentAnalysisResult = runAllDataAnalysis(text);
+  redrawAllLayers(currentAnalysisResult);
+
   // Open Ray Ray chat if needed
   document.getElementById('rayray-container').classList.add('open');
   // Autofill Ray Ray's input with feedback request


### PR DESCRIPTION
## Summary
- add global `currentAnalysisResult`
- fetch scene text by title and analyze when a scene is selected
- redraw canvas layers with analysis output

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6879135cb87c832f90dd2c8f8f2c6af6