### PR TITLE
Respect canvas layer toggles

### DIFF
--- a/public/drafting.html
+++ b/public/drafting.html
@@ -65,12 +65,12 @@
           <canvas id="theme-layer" class="visual-layer" width="700" height="400"></canvas>
         </div>
         <div id="layer-controls" style="margin-top: 10px; text-align: center;">
-          <label><input type="checkbox" checked onchange="toggleLayer('motif-layer')"> Motif Map</label>
-          <label><input type="checkbox" checked onchange="toggleLayer('emotion-layer')"> Emotion Heatmap</label>
-          <label><input type="checkbox" checked onchange="toggleLayer('character-layer')"> Character Timeline</label>
-          <label><input type="checkbox" checked onchange="toggleLayer('pacing-layer')"> Pacing Graph</label>
-          <label><input type="checkbox" checked onchange="toggleLayer('structure-layer')"> Structure Flow</label>
-          <label><input type="checkbox" checked onchange="toggleLayer('theme-layer')"> Theme Network</label>
+          <label><input type="checkbox" id="toggle-motif-layer" checked onchange="toggleLayer('motif-layer')"> Motif Map</label>
+          <label><input type="checkbox" id="toggle-emotion-layer" checked onchange="toggleLayer('emotion-layer')"> Emotion Heatmap</label>
+          <label><input type="checkbox" id="toggle-character-layer" checked onchange="toggleLayer('character-layer')"> Character Timeline</label>
+          <label><input type="checkbox" id="toggle-pacing-layer" checked onchange="toggleLayer('pacing-layer')"> Pacing Graph</label>
+          <label><input type="checkbox" id="toggle-structure-layer" checked onchange="toggleLayer('structure-layer')"> Structure Flow</label>
+          <label><input type="checkbox" id="toggle-theme-layer" checked onchange="toggleLayer('theme-layer')"> Theme Network</label>
         </div>
       </section>
 

--- a/public/js/drafting-room.js
+++ b/public/js/drafting-room.js
@@ -567,12 +567,35 @@ function drawThemeLayer(data) {
 }
 
 function redrawAllLayers(data) {
-  drawMotifLayer(data);
-  drawEmotionLayer(data);
-  drawCharacterLayer(data);
-  drawPacingLayer(data);
-  drawStructureLayer(data);
-  drawThemeLayer(data);
+  const motifToggle = document.getElementById('toggle-motif-layer');
+  if (!motifToggle || motifToggle.checked) {
+    drawMotifLayer(data);
+  }
+
+  const emotionToggle = document.getElementById('toggle-emotion-layer');
+  if (!emotionToggle || emotionToggle.checked) {
+    drawEmotionLayer(data);
+  }
+
+  const characterToggle = document.getElementById('toggle-character-layer');
+  if (!characterToggle || characterToggle.checked) {
+    drawCharacterLayer(data);
+  }
+
+  const pacingToggle = document.getElementById('toggle-pacing-layer');
+  if (!pacingToggle || pacingToggle.checked) {
+    drawPacingLayer(data);
+  }
+
+  const structureToggle = document.getElementById('toggle-structure-layer');
+  if (!structureToggle || structureToggle.checked) {
+    drawStructureLayer(data);
+  }
+
+  const themeToggle = document.getElementById('toggle-theme-layer');
+  if (!themeToggle || themeToggle.checked) {
+    drawThemeLayer(data);
+  }
 }
 
 // ===============================================


### PR DESCRIPTION
## Summary
- add IDs to layer toggle checkboxes
- skip drawing canvases in `redrawAllLayers` when their checkbox is unchecked

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687922ce7cd8832f9c3e82a38be2c281