### PR TITLE
Add feedback saving controls

### DIFF
--- a/public/drafting.html
+++ b/public/drafting.html
@@ -97,6 +97,10 @@
     <div id="feedback-tray">
       <h3>🤖 Ray Ray's Feedback</h3>
       <div id="feedback-content">Ask Ray Ray for feedback on your scenes!</div>
+      <div id="save-controls">
+        <button onclick="saveTextFeedback(currentProject, { scene: getCurrentSceneTitle(), content: latestRayRayReply })">💾 Save Feedback</button>
+        <button onclick="saveVisualizerImage('drafting-room-' + Date.now())">🖼️ Save Visual Snapshot</button>
+      </div>
     </div>
   </div>
 
@@ -115,6 +119,7 @@
     </div>
   </div>
 
+  <script src="js/save-feedback.js"></script>
   <script src="js/drafting-room.js"></script>
 </body>
 </html>

--- a/public/js/drafting-room.css
+++ b/public/js/drafting-room.css
@@ -359,6 +359,17 @@ main {
   margin-bottom: 0.5em;
 }
 
+#save-controls {
+  padding: 10px;
+  display: none;
+  display: flex;
+  gap: 6px;
+}
+
+#save-controls button {
+  flex: 1;
+}
+
 /* Ray Ray Chat Window */
 #rayray-container {
   position: fixed;

--- a/public/js/drafting-room.js
+++ b/public/js/drafting-room.js
@@ -182,6 +182,15 @@ let currentProject = null;
 let projects = {};
 let currentSceneIndex = null;
 let autosaveTimer;
+let latestRayRayReply = '';
+
+function getCurrentSceneTitle() {
+  if (currentSceneIndex !== null && currentProject && projects[currentProject]) {
+    const scene = projects[currentProject].scenes[currentSceneIndex];
+    return scene.title || `Scene ${currentSceneIndex + 1}`;
+  }
+  return 'Text Analysis';
+}
 
 // ===============================================
 // CORE PROJECT MANAGEMENT
@@ -632,6 +641,10 @@ function addFeedbackToTray(sceneTitle, feedback) {
 
   feedbackContent.appendChild(entry);
   feedbackContent.scrollTop = feedbackContent.scrollHeight;
+
+  latestRayRayReply = feedback;
+  const controls = document.getElementById('save-controls');
+  if (controls) controls.style.display = 'block';
 }
 
 function analyzeSceneWithRayRay(scene) {
@@ -794,6 +807,7 @@ Please provide feedback on this text considering:
     
     if (data.choices && data.choices[0] && data.choices[0].message) {
       botMsg.textContent = "Ray Ray: " + data.choices[0].message.content;
+      latestRayRayReply = data.choices[0].message.content;
       
       // Add feedback to tray
       const sceneTitle = currentSceneIndex !== null ? 
@@ -849,6 +863,7 @@ Your writing shows ${analysisData.telemetry.avgSentenceLength > 15 ? 'sophistica
 [Demo Mode: Full AI analysis available when API is connected]`;
         
         botMsg.textContent = "Ray Ray: " + demoFeedback;
+        latestRayRayReply = demoFeedback;
         
         // Add feedback to tray
         const sceneTitle = currentSceneIndex !== null ? 
@@ -865,6 +880,7 @@ Your writing shows ${analysisData.telemetry.avgSentenceLength > 15 ? 'sophistica
           const quickAnalysis = runAllDataAnalysis(textForAnalysis);
           const simpleFeedback = `I've analyzed your text (${quickAnalysis.telemetry.wordCount} words, ${quickAnalysis.telemetry.sentenceCount} sentences). The writing shows ${quickAnalysis.telemetry.avgSentenceLength > 15 ? 'complex structure' : 'clear flow'} with ${quickAnalysis.telemetry.dialoguePercent}% dialogue. Key themes include: ${quickAnalysis.motifMap.map(m => m.word).join(', ')}. [Demo mode - API connection needed for full analysis]`;
           botMsg.textContent = "Ray Ray: " + simpleFeedback;
+          latestRayRayReply = simpleFeedback;
           addFeedbackToTray("Quick Analysis", simpleFeedback);
         } else {
           botMsg.textContent = "Ray Ray: I'm having trouble understanding. Could you rephrase that?";
@@ -919,7 +935,8 @@ ${analysisData.characterMap.length > 0 ?
 [Note: This is demo mode - connect to DeepSeek API for full personalized feedback]`;
       
       botMsg.textContent = "Ray Ray: " + demoFeedback;
-      
+      latestRayRayReply = demoFeedback;
+
       // Add feedback to tray
       const sceneTitle = currentSceneIndex !== null ? 
         (projects[currentProject].scenes[currentSceneIndex].title || `Scene ${currentSceneIndex + 1}`) : 
@@ -935,6 +952,7 @@ ${analysisData.characterMap.length > 0 ?
         const quickAnalysis = runAllDataAnalysis(textForAnalysis);
         const simpleFeedback = `I've analyzed your text (${quickAnalysis.telemetry.wordCount} words, ${quickAnalysis.telemetry.sentenceCount} sentences). The writing shows ${quickAnalysis.telemetry.avgSentenceLength > 15 ? 'complex structure' : 'clear flow'} with ${quickAnalysis.telemetry.dialoguePercent}% dialogue. Key themes include: ${quickAnalysis.motifMap.map(m => m.word).join(', ')}. [Demo mode - API connection needed for full analysis]`;
         botMsg.textContent = "Ray Ray: " + simpleFeedback;
+        latestRayRayReply = simpleFeedback;
         addFeedbackToTray("Quick Analysis", simpleFeedback);
       } else {
         botMsg.textContent = "Ray Ray: I'm having trouble understanding. Could you rephrase that?";

--- a/public/js/save-feedback.js
+++ b/public/js/save-feedback.js
@@ -1,0 +1,29 @@
+function saveTextFeedback(projectId, feedbackObj) {
+  const key = `feedback_${projectId}_${Date.now()}`;
+  localStorage.setItem(key, JSON.stringify(feedbackObj));
+  alert('Feedback saved!');
+}
+
+function saveVisualizerImage(filename = 'visual_feedback.png') {
+  const visualizer = document.getElementById('visualizer');
+  if (!visualizer) return;
+
+  const width = visualizer.offsetWidth;
+  const height = visualizer.offsetHeight;
+  const tempCanvas = document.createElement('canvas');
+  tempCanvas.width = width;
+  tempCanvas.height = height;
+  const tempCtx = tempCanvas.getContext('2d');
+
+  Array.from(visualizer.querySelectorAll('canvas')).forEach(layer => {
+    if (layer.style.display !== 'none') {
+      tempCtx.drawImage(layer, 0, 0, width, height);
+    }
+  });
+
+  const url = tempCanvas.toDataURL('image/png');
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = filename;
+  a.click();
+}


### PR DESCRIPTION
## Summary
- track latest Ray Ray feedback and expose helper to get current scene title
- show save controls when feedback appears
- allow saving feedback text and visual snapshots
- include new button markup and styling

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68792a294cb4832fb939d70f3d14eb69