### PR TITLE
Add per-project notes support

### DIFF
--- a/public/drafting.html
+++ b/public/drafting.html
@@ -84,10 +84,13 @@
           <label>Conflict: <input type="range" min="0" max="5" id="conflict-slider" /></label>
           <label>Reveal: <input type="range" min="0" max="5" id="reveal-slider" /></label>
         </div>
+        <label for="scene-note">Scene Note:</label>
+        <textarea id="scene-note" placeholder="Your note for this scene..."></textarea>
       </aside>
 
       <aside id="junk-drawer" class="hidden">
         <h3>🗒 Junk Drawer</h3>
+        <textarea id="junk-drawer-text" placeholder="Project notes..."></textarea>
         <button id="add-note">+ New Note</button>
         <div id="notes-container"></div>
       </aside>


### PR DESCRIPTION
## Summary
- add `scene-note` textarea and input for junk drawer text
- save junk drawer text per project via dynamic localStorage keys
- allow each scene to store its own note per scene
- autosave junk drawer text and scene notes

## Testing
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_687933c29924832f839aba8be28df43a