### PR TITLE
Add template insertion UI

### DIFF
--- a/public/drafting.html
+++ b/public/drafting.html
@@ -45,6 +45,17 @@
 
       <section id="scene-editor" class="hidden">
         <h2 id="scene-title">✍️ Scene Editor</h2>
+        <div id="template-control">
+          <label for="template-selector">Insert Template:</label>
+          <select id="template-selector">
+            <option value="emotional-turn">Emotional Turn</option>
+            <option value="reversal">Reversal</option>
+            <option value="internal-dilemma">Internal Dilemma</option>
+            <option value="power-shift">Power Shift</option>
+          </select>
+          <button id="insert-template">Insert</button>
+        </div>
+        <div id="beat-stack"></div>
         <textarea id="scene-text" placeholder="Write your scene here..."></textarea>
         <div id="word-count">Words: 0</div>
         <button id="save-scene">Save My Work</button>

--- a/public/js/drafting-room.css
+++ b/public/js/drafting-room.css
@@ -194,6 +194,25 @@ main {
   color: #ccc;
 }
 
+#template-control {
+  display: flex;
+  align-items: center;
+  gap: 0.5em;
+  margin-bottom: 0.5em;
+}
+
+#beat-stack {
+  margin-bottom: 1em;
+}
+
+.beat-block {
+  background: #333;
+  padding: 0.5em;
+  margin: 0.25em 0;
+  border-radius: 4px;
+  color: #f4f4f4;
+}
+
 /* Visualizer */
 #visualizer-section {
   background: #1a1a1a;

--- a/public/js/drafting-room.js
+++ b/public/js/drafting-room.js
@@ -179,6 +179,10 @@ const conflictSlider = document.getElementById('conflict-slider');
 const revealSlider = document.getElementById('reveal-slider');
 const sceneNote = document.getElementById('scene-note');
 
+const templateSelector = document.getElementById('template-selector');
+const insertTemplateBtn = document.getElementById('insert-template');
+const beatStack = document.getElementById('beat-stack');
+
 // State
 let currentProject = null;
 let projects = {};
@@ -1047,6 +1051,34 @@ Object.entries(DRAW_FUNCTIONS).forEach(([name, fn]) => {
 
 // Junk drawer
 addNoteBtn.onclick = addJunkNote;
+
+if (insertTemplateBtn) {
+  insertTemplateBtn.addEventListener('click', () => {
+    const tpl = templateSelector ? templateSelector.value : '';
+    let text = '';
+    switch (tpl) {
+      case 'emotional-turn':
+        text = 'Emotional Turn: Describe a change in feeling.';
+        break;
+      case 'reversal':
+        text = 'Reversal: An unexpected outcome occurs.';
+        break;
+      case 'internal-dilemma':
+        text = 'Internal Dilemma: Character faces a tough choice.';
+        break;
+      case 'power-shift':
+        text = 'Power Shift: Control moves to a different character.';
+        break;
+      default:
+        text = '';
+    }
+    const div = document.createElement('div');
+    div.className = 'beat-block';
+    div.contentEditable = true;
+    div.textContent = text;
+    if (beatStack) beatStack.appendChild(div);
+  });
+}
 
 // ===============================================
 // INITIALIZATION


### PR DESCRIPTION
## Summary
- add 'Insert Template' selector to scene editor
- style template controls and new beat blocks
- implement template insertion logic

## Testing
- `npm test` *(fails: Missing script)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68793cf12d1c832f925524bca8ccb5b4