### PR TITLE
Add tags and context-based template suggestion

### DIFF
--- a/public/drafting.html
+++ b/public/drafting.html
@@ -48,10 +48,10 @@
         <div id="template-control">
           <label for="template-selector">Insert Template:</label>
           <select id="template-selector">
-            <option value="emotional-turn">Emotional Turn</option>
-            <option value="reversal">Reversal</option>
-            <option value="internal-dilemma">Internal Dilemma</option>
-            <option value="power-shift">Power Shift</option>
+            <option value="Emotional Turn">Emotional Turn</option>
+            <option value="Power Shift">Power Shift</option>
+            <option value="Setup">Setup</option>
+            <option value="Escalation">Escalation</option>
           </select>
           <button id="insert-template">Insert</button>
         </div>

--- a/public/js/drafting-room.js
+++ b/public/js/drafting-room.js
@@ -185,11 +185,42 @@ const beatStack = document.getElementById('beat-stack');
 
 // Beat template scaffolds
 const beatTemplates = [
-  { name: 'emotional-turn', scaffold: 'Emotional Turn: Describe a change in feeling.' },
-  { name: 'reversal', scaffold: 'Reversal: An unexpected outcome occurs.' },
-  { name: 'internal-dilemma', scaffold: 'Internal Dilemma: Character faces a tough choice.' },
-  { name: 'power-shift', scaffold: 'Power Shift: Control moves to a different character.' }
+  {
+    name: 'Emotional Turn',
+    scaffold: 'The character feels [emotion] until [event] flips it to [new emotion].',
+    tags: ['emotion', 'turn', 'internal', 'Act II']
+  },
+  {
+    name: 'Power Shift',
+    scaffold: '[Character] gains or loses control after [event].',
+    tags: ['structure', 'tension', 'Act III']
+  },
+  {
+    name: 'Setup',
+    scaffold: 'We introduce [idea/item] that will matter later.',
+    tags: ['foreshadow', 'Act I', 'calm']
+  },
+  {
+    name: 'Escalation',
+    scaffold: '[Conflict] gets worse as [complication] is introduced.',
+    tags: ['tension', 'Act II', 'fast']
+  }
 ];
+
+// Suggest templates based on context tags
+function suggestTemplates(context = {}) {
+  const values = Object.values(context);
+  return beatTemplates
+    .map(tpl => {
+      const matchCount = tpl.tags ? tpl.tags.reduce((count, tag) => {
+        return values.includes(tag) ? count + 1 : count;
+      }, 0) : 0;
+      return { tpl, matchCount };
+    })
+    .filter(item => item.matchCount > 0)
+    .sort((a, b) => b.matchCount - a.matchCount)
+    .map(item => item.tpl);
+}
 
 // State
 let currentProject = null;


### PR DESCRIPTION
## Summary
- add template tags to help classify beat templates
- add a `suggestTemplates` helper in the drafting room script
- update template dropdown values to match new template names

## Testing
- `node -c public/js/drafting-room.js`

------
https://chatgpt.com/codex/tasks/task_e_6879454a2c98832fbdb5ff8876ab8ed9